### PR TITLE
Add loop condition for sequencer

### DIFF
--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/NINA.Plugin.Assistant.csproj
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/NINA.Plugin.Assistant.csproj
@@ -402,6 +402,7 @@
     <Compile Include="Plan\Scoring\Rules\SettingSoonestRule.cs" />
     <Compile Include="Sequencer\PlanTakeExposure.cs" />
     <Compile Include="Sequencer\PlanTargetContainerStrategy.cs" />
+    <Compile Include="Sequencer\IncompleteProjectCondition.cs" />
     <Compile Include="Sequencer\SchedulerTestCondition.cs" />
     <Compile Include="Sequencer\TargetSchedulerContainer.cs" />
     <Compile Include="Sequencer\TargetSchedulerContainerTemplate.xaml.cs">

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/Planner.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/Planner.cs
@@ -421,6 +421,18 @@ namespace Assistant.NINAPlugin.Plan {
             return instructions;
         }
 
+        public bool ProjectsIncomplete() {
+            if (projects == null)
+            {
+                projects = GetProjects();
+            }
+            foreach (IPlanProject project in projects)
+            {
+                if (ProjectIsInComplete(project)) { return true; }
+            }
+            return false;
+        }
+
         private bool NoProjects(List<IPlanProject> projects) {
             return projects == null || projects.Count == 0;
         }

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Sequencer/IncompleteProjectCondition.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Sequencer/IncompleteProjectCondition.cs
@@ -1,0 +1,58 @@
+﻿using Assistant.NINAPlugin.Database;
+using Assistant.NINAPlugin.Plan;
+using Assistant.NINAPlugin.Util;
+using Newtonsoft.Json;
+using NINA.Core.Model;
+using NINA.Profile.Interfaces;
+using NINA.Sequencer.Conditions;
+using NINA.Sequencer.SequenceItem;
+using System;
+using System.ComponentModel.Composition;
+
+namespace Assistant.NINAPlugin.Sequencer {
+
+    [ExportMetadata("Name", "Loop while projects incomplete")]
+    [ExportMetadata("Description", "Loop condition for Target Scheduler, will loop until all projects are completed")]
+    [ExportMetadata("Icon", "Scheduler.SchedulerSVG")]
+    [ExportMetadata("Category", "Lbl_SequenceCategory_Condition")]
+    [Export(typeof(ISequenceCondition))]
+    [JsonObject(MemberSerialization.OptIn)]
+    public class IncompleteProjectCondition : SequenceCondition {
+
+        private readonly IProfileService profileService;
+
+        [ImportingConstructor]
+        public IncompleteProjectCondition(IProfileService profileService) {
+            this.profileService = profileService;
+        }
+
+        private IncompleteProjectCondition(IncompleteProjectCondition cloneMe) : this(cloneMe.profileService) {
+            CopyMetaData(cloneMe);
+        }
+
+        public override object Clone() {
+            return new IncompleteProjectCondition(this);
+        }
+
+        public override bool Check(ISequenceItem previousItem, ISequenceItem nextItem) {
+            try
+            {
+                SchedulerPlanLoader loader = new SchedulerPlanLoader(profileService.ActiveProfile);
+                SchedulerDatabaseInteraction database = new SchedulerDatabaseInteraction();
+                Planner plan = new Planner(DateTime.Now, profileService, loader.GetProfilePreferences(database.GetContext()));
+
+                return plan.ProjectsIncomplete();
+            }
+            catch (Exception ex)
+            {
+                TSLogger.Error($"exception reading database: {ex.StackTrace}");
+                throw new SequenceEntityFailedException($"Scheduler: exception reading database: {ex.Message}", ex);
+            }
+        }
+
+        public override string ToString() {
+            return $"Condition: {nameof(IncompleteProjectCondition)}";
+        }
+
+    }
+}


### PR DESCRIPTION
Loop condition that loops infinitely as long as there are active projects/targets. Useful for multi-night automatic scripts, a bit smarter than using a "Loop for Iterations" condition.

I ran some basic tests, more real-world cases are being tested, but it's a pretty simple add-on.