### PR TITLE
Moon Must Be Down Option

### DIFF
--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Plan/ExposureCompletionHelperTest.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Plan/ExposureCompletionHelperTest.cs
@@ -357,6 +357,7 @@ namespace NINA.Plugin.Assistant.Test.Plan {
         public double MoonRelaxScale { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public double MoonRelaxMaxAltitude { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public double MoonRelaxMinAltitude { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool MoonDownEnabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public double MaximumHumidity { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public bool Rejected { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string RejectedReason { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Controls/AssistantManager/ExposureTemplateView.xaml
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Controls/AssistantManager/ExposureTemplateView.xaml
@@ -410,6 +410,26 @@
                 IsEnabled="{Binding RelaxEnabled}"
                 Text="{Binding ExposureTemplateProxy.ExposureTemplate.MoonRelaxMaxAltitude, Converter={StaticResource DegreesDisplayConverter}}"
                 Visibility="{Binding ShowEditView, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
+
+            <TextBlock
+                VerticalAlignment="Center"
+                FontWeight="Bold"
+                IsEnabled="{Binding RelaxEnabled}"
+                Text="Moon Must Be Down"
+                ToolTip="Moon avoidance is absolute above the Minimum Altitude, regardless of separation or moon phase"
+                ToolTipService.ShowOnDisabled="True" />
+            <CheckBox
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                IsEnabled="{Binding RelaxEnabled}"
+                IsChecked="{Binding Path=MoonDownEnabledProxy, Mode=TwoWay}"
+                Visibility="{Binding ShowEditView, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+            <TextBlock
+                MaxHeight="20"
+                Margin="3,3,0,0"
+                IsEnabled="{Binding RelaxEnabled}"
+                Text="{Binding ExposureTemplateProxy.ExposureTemplate.MoonDownEnabled}"
+                Visibility="{Binding ShowEditView, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
         </UniformGrid>
     </StackPanel>
 </UserControl>

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Controls/AssistantManager/ExposureTemplateViewVM.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Controls/AssistantManager/ExposureTemplateViewVM.cs
@@ -48,6 +48,7 @@ namespace Assistant.NINAPlugin.Controls.AssistantManager {
             }
 
             MoonAvoidanceEnabledProxy = ExposureTemplateProxy.Proxy.MoonAvoidanceEnabled;
+            MoonDownEnabledProxy = ExposureTemplateProxy.Proxy.MoonDownEnabled;
             RelaxScaleProxy = ExposureTemplateProxy.Proxy.MoonRelaxScale;
         }
 
@@ -116,6 +117,22 @@ namespace Assistant.NINAPlugin.Controls.AssistantManager {
                 ExposureTemplateProxy.Proxy.MoonAvoidanceEnabled = _moonAvoidanceEnabledProxy;
                 RaisePropertyChanged(nameof(MoonAvoidanceEnabledProxy));
                 SetRelaxEnabled();
+            }
+        }
+
+        private bool _moonDownEnabledProxy;
+
+        public bool MoonDownEnabledProxy
+        {
+            get
+            {
+                return _moonDownEnabledProxy;
+            }
+            set
+            {
+                _moonDownEnabledProxy = value;
+                ExposureTemplateProxy.Proxy.MoonDownEnabled = _moonDownEnabledProxy;
+                RaisePropertyChanged(nameof(MoonDownEnabledProxy));
             }
         }
 

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Migrate/16.sql
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Migrate/16.sql
@@ -1,0 +1,6 @@
+/*
+*/
+
+ALTER TABLE exposuretemplate ADD COLUMN moondownenabled INTEGER DEFAULT 0;
+
+PRAGMA user_version = 16;

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Migrate/SQL.resx
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Migrate/SQL.resx
@@ -139,6 +139,9 @@
   <data name="15" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>15.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="16" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>16.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="2" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>2.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Schema/ExposureTemplate.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Schema/ExposureTemplate.cs
@@ -30,6 +30,7 @@ namespace Assistant.NINAPlugin.Database.Schema {
         public double moonRelaxScale { get; set; }
         public double moonRelaxMaxAltitude { get; set; }
         public double moonRelaxMinAltitude { get; set; }
+        public bool moonDownEnabled { get; set; }
 
         public double maximumHumidity { get; set; }
 
@@ -169,6 +170,17 @@ namespace Assistant.NINAPlugin.Database.Schema {
         }
 
         [NotMapped]
+        public bool MoonDownEnabled
+        {
+            get { return moonDownEnabled; }
+            set
+            {
+                moonDownEnabled = value;
+                RaisePropertyChanged(nameof(MoonDownEnabled));
+            }
+        }
+
+        [NotMapped]
         public double MaximumHumidity {
             get { return maximumHumidity; }
             set {
@@ -234,6 +246,7 @@ namespace Assistant.NINAPlugin.Database.Schema {
             copy.MoonRelaxScale = MoonRelaxScale;
             copy.MoonRelaxMaxAltitude = MoonRelaxMaxAltitude;
             copy.MoonRelaxMinAltitude = MoonRelaxMinAltitude;
+            copy.MoonDownEnabled = MoonDownEnabled;
             copy.MaximumHumidity = MaximumHumidity;
 
             return copy;
@@ -256,6 +269,7 @@ namespace Assistant.NINAPlugin.Database.Schema {
             sb.AppendLine($"MoonRelaxScale: {MoonRelaxScale}");
             sb.AppendLine($"MoonRelaxMaxAltitude: {MoonRelaxMaxAltitude}");
             sb.AppendLine($"MoonRelaxMinAltitude: {MoonRelaxMinAltitude}");
+            sb.AppendLine($"MoonDownEnabled: {MoonDownEnabled}");
             sb.AppendLine($"MaximumHumidity: {MaximumHumidity}");
 
             return sb.ToString();

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/MoonAvoidanceExpert.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/MoonAvoidanceExpert.cs
@@ -36,6 +36,13 @@ namespace Assistant.NINAPlugin.Plan {
                 return false;
             }
 
+            // Avoidance is absolute regardless of moon phase or separation if Moon Must Be Down is enabled
+            if (moonAltitude >= planExposure.MoonRelaxMinAltitude && planExposure.MoonDownEnabled)
+            {
+                TSLogger.Info($"moon avoidance absolute: moon altitude ({moonAltitude}) is above relax min altitude ({planExposure.MoonRelaxMinAltitude}) with Moon Must Be Down enabled");
+                return true;
+            }
+
             double moonSeparationParameter = planExposure.MoonAvoidanceSeparation;
             double moonWidthParameter = planExposure.MoonAvoidanceWidth;
 

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/PlannerEmulator.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/PlannerEmulator.cs
@@ -583,6 +583,7 @@ namespace Assistant.NINAPlugin.Plan {
         public double MoonRelaxScale { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public double MoonRelaxMaxAltitude { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public double MoonRelaxMinAltitude { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool MoonDownEnabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public double MaximumHumidity { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public PlanExposureEmulator() {

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/SchedulerPlan.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/SchedulerPlan.cs
@@ -557,6 +557,7 @@ namespace Assistant.NINAPlugin.Plan {
         double MoonRelaxScale { get; set; }
         double MoonRelaxMaxAltitude { get; set; }
         double MoonRelaxMinAltitude { get; set; }
+        bool MoonDownEnabled { get; set; }
         double MaximumHumidity { get; set; }
 
         bool Rejected { get; set; }
@@ -592,6 +593,7 @@ namespace Assistant.NINAPlugin.Plan {
         public double MoonRelaxScale { get; set; }
         public double MoonRelaxMaxAltitude { get; set; }
         public double MoonRelaxMinAltitude { get; set; }
+        public bool MoonDownEnabled { get; set; }
 
         public double MaximumHumidity { get; set; }
 
@@ -622,6 +624,7 @@ namespace Assistant.NINAPlugin.Plan {
             this.MoonRelaxScale = exposureTemplate.MoonRelaxScale;
             this.MoonRelaxMaxAltitude = exposureTemplate.MoonRelaxMaxAltitude;
             this.MoonRelaxMinAltitude = exposureTemplate.MoonRelaxMinAltitude;
+            this.MoonDownEnabled = exposureTemplate.MoonDownEnabled;
 
             this.MaximumHumidity = exposureTemplate.MaximumHumidity;
 


### PR DESCRIPTION
Added an option to moon avoidance to avoid imaging when the moon is above the minimum altitude regardless of phase or separation.

I'm unsure if I managed to get all the database stuff correct.  I've added a test for the new functionality which now passes.