### PR TITLE
Feature: Overhead Obstructions

### DIFF
--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Astrometry/HorizonDefinitionTest.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Astrometry/HorizonDefinitionTest.cs
@@ -15,7 +15,7 @@ namespace NINA.Plugin.Assistant.Test.Astrometry {
 
         [Test]
         public void TestMinimumAltitudeOnly() {
-            HorizonDefinition sut = new HorizonDefinition(11);
+            HorizonDefinition sut = new HorizonDefinition(11, 0);
             sut.IsCustom().Should().BeFalse();
             sut.GetFixedMinimumAltitude().Should().Be(11);
             sut.GetTargetAltitude(null).Should().Be(11);

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Astrometry/OverheadObstacleAvoidanceTest.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Astrometry/OverheadObstacleAvoidanceTest.cs
@@ -1,0 +1,112 @@
+﻿using Assistant.NINAPlugin.Astrometry;
+using Assistant.NINAPlugin.Database.Schema;
+using Assistant.NINAPlugin.Plan;
+using Assistant.NINAPlugin.Astrometry;
+using FluentAssertions;
+using Moq;
+using NINA.Plugin.Assistant.Test.Plan;
+using NINA.Profile.Interfaces;
+using NUnit.Framework;
+using System;
+using NINA.Core.Model;
+
+namespace NINA.Plugin.Assistant.Test.Astrometry {
+
+    [TestFixture]
+    public class OverheadObstacleAvoidanceTest
+    {
+        [Test]
+        public void ObstacleAvoidance1() {
+            Mock<IProfile> profileMock = new Mock<IProfile>();
+            profileMock.SetupProperty(m => m.AstrometrySettings.Latitude, TestUtil.TEST_LOCATION_1.Latitude);
+            profileMock.SetupProperty(m => m.AstrometrySettings.Longitude, TestUtil.TEST_LOCATION_1.Longitude);
+            profileMock.SetupProperty(m => m.AstrometrySettings.Elevation, TestUtil.TEST_LOCATION_1.Elevation);
+
+            Mock<IPlanProject> pp1 = PlanMocks.GetMockPlanProject("pp1", ProjectState.Active);
+            pp1.SetupProperty(m => m.HorizonDefinition, new HorizonDefinition(null, 0, 0, 40.5)); // Horizon with a wide 40.5 degree overhead obstruction radius
+
+            Mock<IPlanTarget> pt = PlanMocks.GetMockPlanTarget("M42", TestUtil.M42);
+            pt.SetupProperty(m => m.Project, pp1.Object);
+
+            Mock<IPlanExposure> pf = PlanMocks.GetMockPlanExposure("Ha", 10, 0);
+            PlanMocks.AddMockPlanFilter(pt, pf);
+            PlanMocks.AddMockPlanTarget(pp1, pt);
+            OverheadObstacleAvoidance testSubject = new OverheadObstacleAvoidance(profileMock.Object);
+            testSubject.InterceptsObstacle(pt.Object, pf.Object, M42Crossing44Deg()).Should().BeTrue(); // 49.5deg up, just above obstruction
+        }
+
+        [Test]
+        public void ObstacleAvoidance2()
+        {
+            Mock<IProfile> profileMock = new Mock<IProfile>();
+            profileMock.SetupProperty(m => m.AstrometrySettings.Latitude, TestUtil.TEST_LOCATION_1.Latitude);
+            profileMock.SetupProperty(m => m.AstrometrySettings.Longitude, TestUtil.TEST_LOCATION_1.Longitude);
+            profileMock.SetupProperty(m => m.AstrometrySettings.Elevation, TestUtil.TEST_LOCATION_1.Elevation);
+
+            Mock<IPlanProject> pp1 = PlanMocks.GetMockPlanProject("pp1", ProjectState.Active);
+            pp1.SetupProperty(m => m.HorizonDefinition, new HorizonDefinition(null, 0, 0, 40.5));
+
+            Mock<IPlanTarget> pt = PlanMocks.GetMockPlanTarget("M42", TestUtil.M42);
+            pt.SetupProperty(m => m.Project, pp1.Object);
+
+            Mock<IPlanExposure> pf = PlanMocks.GetMockPlanExposure("Ha", 10, 0);
+            PlanMocks.AddMockPlanFilter(pt, pf);
+            PlanMocks.AddMockPlanTarget(pp1, pt);
+            OverheadObstacleAvoidance testSubject = new OverheadObstacleAvoidance(profileMock.Object);
+            testSubject.InterceptsObstacle(pt.Object, pf.Object, M42Crossing44Deg().AddHours(-1)).Should().BeFalse(); // Not above obstruction yet
+        }
+
+        [Test]
+        public void ObstacleAvoidance3()
+        {
+            Mock<IProfile> profileMock = new Mock<IProfile>();
+            profileMock.SetupProperty(m => m.AstrometrySettings.Latitude, TestUtil.TEST_LOCATION_1.Latitude);
+            profileMock.SetupProperty(m => m.AstrometrySettings.Longitude, TestUtil.TEST_LOCATION_1.Longitude);
+            profileMock.SetupProperty(m => m.AstrometrySettings.Elevation, TestUtil.TEST_LOCATION_1.Elevation);
+
+            Mock<IPlanProject> pp1 = PlanMocks.GetMockPlanProject("pp1", ProjectState.Active);
+            pp1.SetupProperty(m => m.HorizonDefinition, new HorizonDefinition(null, 0, 0, 40.5));
+
+            Mock<IPlanTarget> pt = PlanMocks.GetMockPlanTarget("M42", TestUtil.M42);
+            pt.SetupProperty(m => m.Project, pp1.Object);
+
+            Mock<IPlanExposure> pf = PlanMocks.GetMockPlanExposure("Ha", 10, 0);
+            PlanMocks.AddMockPlanFilter(pt, pf);
+            PlanMocks.AddMockPlanTarget(pp1, pt);
+            OverheadObstacleAvoidance testSubject = new OverheadObstacleAvoidance(profileMock.Object);
+            testSubject.InterceptsObstacle(pt.Object, pf.Object, M42Crossing44Deg().AddHours(-1), M42Crossing44Deg().AddHours(5)).Should().BeTrue(); // Rises above obstruction along the way
+        }
+
+        [Test]
+        public void ObstacleAvoidance4()
+        {
+            Mock<IProfile> profileMock = new Mock<IProfile>();
+            profileMock.SetupProperty(m => m.AstrometrySettings.Latitude, TestUtil.TEST_LOCATION_1.Latitude);
+            profileMock.SetupProperty(m => m.AstrometrySettings.Longitude, TestUtil.TEST_LOCATION_1.Longitude);
+            profileMock.SetupProperty(m => m.AstrometrySettings.Elevation, TestUtil.TEST_LOCATION_1.Elevation);
+
+            Mock<IPlanProject> pp1 = PlanMocks.GetMockPlanProject("pp1", ProjectState.Active);
+            pp1.SetupProperty(m => m.HorizonDefinition, new HorizonDefinition(null, 0, 0, 40.5));
+
+            Mock<IPlanTarget> pt = PlanMocks.GetMockPlanTarget("M42", TestUtil.M42);
+            pt.SetupProperty(m => m.Project, pp1.Object);
+
+            Mock<IPlanExposure> pf = PlanMocks.GetMockPlanExposure("Ha", 10, 0);
+            PlanMocks.AddMockPlanFilter(pt, pf);
+            PlanMocks.AddMockPlanTarget(pp1, pt);
+            OverheadObstacleAvoidance testSubject = new OverheadObstacleAvoidance(profileMock.Object);
+            testSubject.TimeToInterceptObstacle(pt.Object, pf.Object, M42Crossing44Deg().AddHours(-1), M42Crossing44Deg().AddHours(5)).Should().Be(TimeSpan.FromMinutes(55)); // Rises above obstruction along the way
+        }
+
+        private void AssertTimeInterval(TimeInterval interval, DateTime expectedStart, DateTime expectedEnd) {
+            TimeSpan precision = TimeSpan.FromSeconds(1);
+            interval.StartTime.Should().BeCloseTo(expectedStart, precision);
+            interval.EndTime.Should().BeCloseTo(expectedEnd, precision);
+        }
+
+        private DateTime M42Crossing44Deg()
+        {
+            return new DateTime(2024, 12, 31, 20, 0, 0);
+        }
+    }
+}

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Astrometry/TargetCircumstancesTest.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Astrometry/TargetCircumstancesTest.cs
@@ -11,7 +11,7 @@ namespace NINA.Plugin.Assistant.Test.Astrometry {
         [Test]
         public void TargetCircumstances() {
             TimeInterval twilightSpan = new TimeInterval(new DateTime(2023, 1, 16, 18, 50, 0), new DateTime(2023, 1, 17, 5, 50, 0));
-            var sut = new TargetCircumstances(TestUtil.M42, TestUtil.TEST_LOCATION_4, new HorizonDefinition(10), twilightSpan);
+            var sut = new TargetCircumstances(TestUtil.M42, TestUtil.TEST_LOCATION_4, new HorizonDefinition(10, 0), twilightSpan);
         }
     }
 }

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Astrometry/TestUtil.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Astrometry/TestUtil.cs
@@ -192,7 +192,7 @@ namespace NINA.Plugin.Assistant.Test.Astrometry {
         }
 
         public static HorizonDefinition getHD(double minimumAltitude) {
-            return new HorizonDefinition(minimumAltitude);
+            return new HorizonDefinition(minimumAltitude, 0);
         }
 
         public static void AssertTime(DateTime expected, DateTime? actual, int hours, int minutes, int seconds) {

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Plan/PlanMocks.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant.Test/Plan/PlanMocks.cs
@@ -31,13 +31,13 @@ namespace NINA.Plugin.Assistant.Test.Plan {
             return profileMock;
         }
 
-        public static Mock<IPlanProject> GetMockPlanProject(string name, ProjectState state) {
+        public static Mock<IPlanProject> GetMockPlanProject(string name, ProjectState state, HorizonDefinition horizonDefinition = null) {
             Mock<IPlanProject> pp = new Mock<IPlanProject>();
             pp.SetupAllProperties();
             pp.SetupProperty(m => m.Name, name);
             pp.SetupProperty(m => m.State, state);
             pp.SetupProperty(m => m.Rejected, false);
-            pp.SetupProperty(m => m.HorizonDefinition, new HorizonDefinition(0));
+            pp.SetupProperty(m => m.HorizonDefinition, horizonDefinition == null ? new HorizonDefinition(0, 0) : horizonDefinition);
 
             pp.SetupProperty(m => m.MinimumTime, 30);
             pp.SetupProperty(m => m.MinimumAltitude, 0);

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Astrometry/HorizonDefinition.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Astrometry/HorizonDefinition.cs
@@ -9,18 +9,23 @@ namespace Assistant.NINAPlugin.Astrometry {
     public class HorizonDefinition {
         private bool isBasicMinimumAltitude;
         private readonly double minimumAltitude;
+        private readonly double overheadSpaceLimit;
         private readonly CustomHorizon horizon;
         private readonly double offset;
 
-        public HorizonDefinition(double minimumAltitude) {
+        public HorizonDefinition(double minimumAltitude, double overheadSpaceLimit) {
             Assert.isTrue(minimumAltitude >= 0 && minimumAltitude < 90, "minimumAltitude must be >= 0 and < 90");
             this.minimumAltitude = minimumAltitude;
+            this.overheadSpaceLimit = overheadSpaceLimit;
             this.isBasicMinimumAltitude = true;
         }
 
-        public HorizonDefinition(CustomHorizon customHorizon, double offset, double minimumAltitude = 0) {
+        public HorizonDefinition(CustomHorizon customHorizon, double offset, double minimumAltitude = 0, double overheadSpaceLimit = 0) {
             Assert.isTrue(offset >= 0, "offset must be >= 0");
             Assert.isTrue(minimumAltitude >= 0 && minimumAltitude < 90, "minimumAltitude must be >= 0 and < 90");
+            Assert.isTrue(overheadSpaceLimit <= 90, "maximumAltitude must be > minimumAltitude and <= 90");
+
+            this.overheadSpaceLimit = overheadSpaceLimit;
 
             if (customHorizon != null) {
                 this.minimumAltitude = minimumAltitude;
@@ -39,7 +44,7 @@ namespace Assistant.NINAPlugin.Astrometry {
             }
 
             double raw = Math.Max(horizon.GetAltitude(aat.Azimuth) + offset, minimumAltitude);
-            return raw > 90 ? 90 : raw;
+            return Math.Min(raw, 90);
         }
 
         public bool IsCustom() {
@@ -52,6 +57,11 @@ namespace Assistant.NINAPlugin.Astrometry {
             }
 
             return this.minimumAltitude;
+        }
+
+        public double GetFixedMaximumAltitude()
+        {
+            return 90 - this.overheadSpaceLimit;
         }
 
         public string GetCacheKey() {

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Astrometry/OverheadObstacleAvoidance.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Astrometry/OverheadObstacleAvoidance.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Accord;
+using Assistant.NINAPlugin.Plan;
+using NINA.Astrometry;
+using NINA.Profile.Interfaces;
+
+namespace Assistant.NINAPlugin.Astrometry
+{
+    public class OverheadObstacleAvoidance
+    {
+        private ObserverInfo observerInfo;
+
+        public OverheadObstacleAvoidance(IProfile activeProfile)
+        {
+            this.observerInfo = new ObserverInfo
+            {
+                Latitude = activeProfile.AstrometrySettings.Latitude,
+                Longitude = activeProfile.AstrometrySettings.Longitude,
+                Elevation = activeProfile.AstrometrySettings.Elevation,
+            };
+        }
+
+        public bool InterceptsObstacle(IPlanTarget planTarget, IPlanExposure planExposure, DateTime atTime)
+        {
+            return InterceptsObstacle(planTarget, planExposure, atTime, atTime);
+        }
+
+        public bool InterceptsObstacle(IPlanTarget planTarget, IPlanExposure planExposure, DateTime fromTime, DateTime toTime)
+        {
+            return TimeToInterceptObstacle(planTarget, planExposure, fromTime, toTime).TotalSeconds >= 0;
+        }
+
+        public TimeSpan TimeToInterceptObstacle(IPlanTarget planTarget, IPlanExposure planExposure, DateTime fromTime, DateTime toTime)
+        {
+            double deltaT = Math.Max(planExposure.ExposureLength, 5.0 * 60);
+            // Precision depends on exposure length. Iterating over each "exposure" and check altitudes. Cap at 5 minute exposures min.
+            for (DateTime dt = fromTime; dt.IsLessThanOrEqual(toTime); dt = dt.AddSeconds(deltaT))
+            {
+                double altitude = AstrometryUtils.GetAltitude(observerInfo, planTarget.Coordinates, dt);
+                if (altitude > planTarget.Project.HorizonDefinition.GetFixedMaximumAltitude())
+                {
+                    return dt.Subtract(fromTime);
+                }
+            }
+
+            return TimeSpan.FromSeconds(-1);
+        }
+
+        public TimeSpan TimeToSurpassObstacle(IPlanTarget planTarget, IPlanExposure planExposure, DateTime fromTime, DateTime toTime)
+        {
+            double deltaT = Math.Max(planExposure.ExposureLength, 5.0 * 60);
+            // Precision depends on exposure length. Iterating over each "exposure" and check altitudes. Cap at 5 minute exposures min.
+            for (DateTime dt = toTime; dt.IsGreaterThanOrEqual(fromTime); dt = dt.AddSeconds(-deltaT))
+            {
+                double altitude = AstrometryUtils.GetAltitude(observerInfo, planTarget.Coordinates, dt);
+                if (altitude > planTarget.Project.HorizonDefinition.GetFixedMaximumAltitude())
+                {
+                    return dt.Subtract(fromTime);
+                }
+            }
+
+            return TimeSpan.FromSeconds(-1);
+        }
+    }
+}

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Astrometry/Solver/Solver.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Astrometry/Solver/Solver.cs
@@ -1,6 +1,8 @@
 ﻿using Assistant.NINAPlugin.Util;
 using System;
 using System.Collections.Generic;
+using System.Drawing.Printing;
+using System.Windows.Forms;
 
 namespace Assistant.NINAPlugin.Astrometry.Solver {
 

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Controls/AssistantManager/ProjectView.xaml
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Controls/AssistantManager/ProjectView.xaml
@@ -258,6 +258,35 @@
                        Visibility="{Binding ShowEditView, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
 
             <TextBlock VerticalAlignment="Center"
+           FontWeight="Bold"
+           IsEnabled="{Binding ProjectProxy.Project.UseCustomHorizon}"
+           Text="Overhead obstruction"
+           ToolTip="Radius of an object obstructing the view in a circle above the telescope, such as a balcony or roof."
+           ToolTipService.ShowOnDisabled="True" />
+            <TextBox MaxHeight="20"
+         IsEnabled="{Binding ProjectProxy.Project.UseCustomHorizon}"
+         Visibility="{Binding ShowEditView, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                <TextBox.Text>
+                    <Binding Path="ProjectProxy.Project.OverheadObstructionRadius"
+                 UpdateSourceTrigger="LostFocus">
+                        <Binding.ValidationRules>
+                            <rules:DoubleRangeRule>
+                                <rules:DoubleRangeRule.ValidRange>
+                                    <rules:DoubleRangeChecker Maximum="90"
+                                                  Minimum="0" />
+                                </rules:DoubleRangeRule.ValidRange>
+                            </rules:DoubleRangeRule>
+                        </Binding.ValidationRules>
+                    </Binding>
+                </TextBox.Text>
+            </TextBox>
+            <TextBlock MaxHeight="20"
+           Margin="3,3,0,0"
+           IsEnabled="{Binding ProjectProxy.Project.UseCustomHorizon}"
+           Text="{Binding ProjectProxy.Project.OverheadObstructionRadius, Converter={StaticResource DegreesDisplayConverter}}"
+           Visibility="{Binding ShowEditView, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}" />
+
+            <TextBlock VerticalAlignment="Center"
                        FontWeight="Bold"
                        Text="Meridian Window"
                        ToolTip="Limit imaging to this amount of time on either side of target meridian crossing" />

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Migrate/17.sql
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Migrate/17.sql
@@ -1,0 +1,6 @@
+/*
+*/
+
+ALTER TABLE project ADD COLUMN overheadObstructionRadius REAL NOT NULL DEFAULT 0.0;
+
+PRAGMA user_version = 17;

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Migrate/SQL.resx
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Migrate/SQL.resx
@@ -142,6 +142,9 @@
   <data name="16" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>16.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="17" type="System.Resources.ResXFileRef, System.Windows.Forms">
+	<value>17.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="2" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>2.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Schema/Project.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Database/Schema/Project.cs
@@ -44,6 +44,7 @@ namespace Assistant.NINAPlugin.Database.Schema {
         public int filterSwitchFrequency { get; set; }
         public int ditherEvery { get; set; }
         public int enableGrader { get; set; }
+        public double overheadObstructionRadius { get; set; }
 
         public virtual List<RuleWeight> ruleWeights { get; set; }
         public virtual List<Target> Targets { get; set; }
@@ -61,6 +62,7 @@ namespace Assistant.NINAPlugin.Database.Schema {
             MinimumAltitude = 0;
             UseCustomHorizon = false;
             HorizonOffset = 0;
+            OverheadObstructionRadius = 0;
             MeridianWindow = 0;
             FilterSwitchFrequency = 0;
             DitherEvery = 0;
@@ -257,6 +259,17 @@ namespace Assistant.NINAPlugin.Database.Schema {
             }
         }
 
+        [NotMapped]
+        public double OverheadObstructionRadius
+        {
+            get => overheadObstructionRadius;
+            set
+            {
+                overheadObstructionRadius = value;
+                RaisePropertyChanged(nameof(OverheadObstructionRadius));
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected void RaisePropertyChanged([CallerMemberName] string propertyName = null) {
@@ -284,6 +297,7 @@ namespace Assistant.NINAPlugin.Database.Schema {
             project.enableGrader = enableGrader;
             project.isMosaic = isMosaic;
             project.flatsHandling = flatsHandling;
+            project.overheadObstructionRadius = overheadObstructionRadius;
 
             project.Targets = new List<Target>(Targets.Count);
             Targets.ForEach(item => project.Targets.Add(item.GetPasteCopy(newProfileId)));
@@ -318,6 +332,7 @@ namespace Assistant.NINAPlugin.Database.Schema {
             sb.AppendLine($"MinimumAltitude: {MinimumAltitude}");
             sb.AppendLine($"UseCustomHorizon: {UseCustomHorizon}");
             sb.AppendLine($"HorizonOffset: {HorizonOffset}");
+            sb.AppendLine($"OverheadObstructionRadius: {OverheadObstructionRadius}");
             sb.AppendLine($"MeridianWindow: {MeridianWindow}");
             sb.AppendLine($"FilterSwitchFrequency: {FilterSwitchFrequency}");
             sb.AppendLine($"DitherEvery: {DitherEvery}");

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/SchedulerPlan.cs
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Plan/SchedulerPlan.cs
@@ -347,13 +347,13 @@ namespace Assistant.NINAPlugin.Plan {
             if (project.UseCustomHorizon) {
                 if (profile.AstrometrySettings.Horizon == null) {
                     TSLogger.Warning("project 'Use Custom Horizon' is enabled but no custom horizon was found in the profile, defaulting to Minimum Altitude");
-                    return new HorizonDefinition(project.MinimumAltitude);
+                    return new HorizonDefinition(project.MinimumAltitude, project.overheadObstructionRadius);
                 }
 
-                return new HorizonDefinition(profile.AstrometrySettings.Horizon, project.HorizonOffset, project.MinimumAltitude);
+                return new HorizonDefinition(profile.AstrometrySettings.Horizon, project.HorizonOffset, project.MinimumAltitude, project.OverheadObstructionRadius);
             }
 
-            return new HorizonDefinition(project.MinimumAltitude);
+            return new HorizonDefinition(project.MinimumAltitude, project.overheadObstructionRadius);
         }
     }
 

--- a/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Properties/launchSettings.json
+++ b/NINA.Plugin.Assistant/NINA.Plugin.Assistant/Properties/launchSettings.json
@@ -5,7 +5,7 @@
     },
     "NINA": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\Tom\\source\\repos\\nina\\NINA\\bin\\Debug\\net8.0-windows\\win-x64\\NINA.exe"
+      "executablePath": "C:\\Users\\Daniel Vancura\\OneDrive\\Documents\\GitHub\\nina\\NINA\\bin\\Debug\\net8.0-windows\\win-x64\\NINA.exe"
     },
     "NINA_InstallPath": {
       "commandName": "Executable",


### PR DESCRIPTION
# Problem Statement

Generally we all love to take astrophotography images of objects overhead, as far away from light pollution as possible. However, some unfortunate people like myself don't have the convenience of an open backyard but, in fact, take images from our balconies. Not living on the top floor either means that the select few like myself have to deal with balconies upstairs and therefore aren't able to point our telescopes anywhere near zenith.

## Tried & Somewhat manageable Workarounds

The first thing I was hoping to use in order to solve my situation was to try and setup horizons "above" myself. It doesn't appear they are meant for that (as the name implies ...) so that solution didn't lead anywhere.
The second solution which somewhat solved my problem was to setup triggers that cause the image acquisition to stop whenever my telescope slews above a certain degree over horizon. Looks somewhat like this:
<img width="1275" alt="Screenshot 2025-02-04 at 3 34 14 PM" src="https://github.com/user-attachments/assets/575ecdc8-b84b-4f75-9bb0-fb193931b3e5" />

However, I think it is obvious that this is sacrificing potential imaging time: if TargetScheduler deems a target near zenith the highest priority, it will slew there and then I have to wait for it to settle, when instead I could have maybe taken a few more images of a lower priority target closer to horizon in the meantime. Since TargetScheduler isn't aware of my predicament, it can't help me with that.

# Suggested Addition

I say "suggested addition" cautiously since I know that a) my situation may not be common enough to be considered worthy a new feature in this plugin and b) my solution is sort of brute force. There may be better ways, like setting up a custom second horizon that lets you free-form create an overhead horizon of sorts for better customizability for example, or other solutions I haven't thought of.

So, that out of the way, the suggested solution here is an "Overhead Obstruction" parameter in TargetScheduler's project settings: it would define the radius of a circle above the telescope, so if I say "Overhead Obstruction = 30º", it would translate to: "only take images of targets between the horizon and 60º (90 - 30) above the horizon."

# Disclaimer

By trade I'm not a C# engineer and first thing I did here was to install and figure out how to even use Visual Studio and then brute forced my way forward 😅 please excuse potentially crappy, badly formatted code and other bad practices. The whole pull request is really more a suggestion.

# Test run

Quick test with M31 here, delaying imaging to different times when setting an overhead obstruction radius of 45 & 50 respectively (notice the plan start at the very bottom):
![Screenshot 2025-02-04 160045](https://github.com/user-attachments/assets/c7109a61-387b-40e9-ab12-d40e5c6b5976)
![Screenshot 2025-02-04 155929](https://github.com/user-attachments/assets/082b1894-796f-4c8b-81ef-c3ea6d36572a)

I haven't run this in practice yet. As I write this it is pouring rain, with more to come in the next few days 🥲